### PR TITLE
Add character-set setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,12 @@
 					"default": "",
 					"markdownDescription": "Path to the `dhall-lsp-server` executable"
 				},
+				"vscode-dhall-lsp-server.character-set": {
+					"scope": "window",
+					"type": "string",
+					"default": "",
+					"markdownDescription": "Character set for `dhall format`: Either `unicode` or `ascii`. If left empty, character set will be inferred."
+				},
 				"vscode-dhall-lsp-server.logFile": {
 					"scope": "window",
 					"type": "string",


### PR DESCRIPTION
The language server corresponding changes were implemented as part of https://github.com/dhall-lang/dhall-haskell/pull/2108

Note: We should probably wait until a new release of `dhall-haskell` is cut before releasing this change to the VS code extension.